### PR TITLE
set lastGopDTS smaller then 0

### DIFF
--- a/src/core/remuxer/h264.js
+++ b/src/core/remuxer/h264.js
@@ -35,7 +35,7 @@ export class H264Remuxer extends BaseRemuxer {
             samples: []
         };
         this.samples = [];
-        this.lastGopDTS = 0;
+        this.lastGopDTS = -99999999999999;
         this.gop=[];
         this.firstUnit = true;
 


### PR DESCRIPTION
As discussed in an issue, we have a DTS which is less then 0 so we set the lastGopDTS to  big negative value, so this should be a workaround for the issue