### PR TITLE
don't call client.reset

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -186,9 +186,10 @@ export class WSPlayer {
             }
             let client = this.modules[type].client;
             this.client = new client();
+        } else {
+            this.client.reset();
         }
-
-        this.client.reset();
+        
         if (this.remuxer) {
             this.remuxer.destroy();
             this.remuxer = null;


### PR DESCRIPTION
I think there are many problems on starting and stoping player, one of the problems could be this all is not synchronized. You call multiple times for example this.client.reset also if IMO not needed.

For example in this case why you should call client.reset();
If there is no client it would be created before and the constructor does always call the reset() method. So you don't need to call it a second time. Same thing if lastType changed.

You have to call reset function only if lastType is equal as actual type and if the client already exists, so you can handle this with an else block