### PR TITLE
Failed to execute 'remove' on 'SourceBuffer'

### DIFF
--- a/src/core/presentation/mse.js
+++ b/src/core/presentation/mse.js
@@ -102,8 +102,17 @@ export class MSEBuffer {
             this.cleaning = true;
             promises.push(new Promise((resolve, reject)=>{
                 this.cleanResolvers.push(resolve);
-                this.sourceBuffer.remove(this.sourceBuffer.buffered.start(i), this.sourceBuffer.buffered.end(i));
-                resolve();
+                if (!this.sourceBuffer.updating) {
+                    this.sourceBuffer.remove(this.sourceBuffer.buffered.start(i), this.sourceBuffer.buffered.end(i));
+                    resolve();
+                } else {
+                    this.sourceBuffer.onupdateend = () => {
+                        if (this.sourceBuffer) {
+                            this.sourceBuffer.remove(this.sourceBuffer.buffered.start(i), this.sourceBuffer.buffered.end(i));
+                        }
+                        resolve();
+                    };
+                }
             }));
         }
         return Promise.all(promises);


### PR DESCRIPTION
We wasn't able to figure out which appendBuffer or remove is blocking the requested remove method but we do a change on MSEBuffer.clear() method
In our case this is resolving the issue, but as the lib is very complicated we are not sure if there could be some side effects in some cases