### PR TITLE
There are two much play calls

### DIFF
--- a/src/core/remuxer/remuxer.js
+++ b/src/core/remuxer/remuxer.js
@@ -114,7 +114,7 @@ export class Remuxer {
         }
         this.initialized = true;
         Promise.all(initmse).then(()=>{
-            this.mse.play();
+            //this.mse.play();
             this.enabled = true;
         });
         
@@ -192,7 +192,7 @@ export class Remuxer {
         this.clientEventSource.on('clear', ()=>{
             this.reset();
             this.mse.clear().then(()=>{
-                this.mse.play();
+                //this.mse.play();
             });
         });
     }


### PR DESCRIPTION
On testing the player we noticed that there are many play events so we tried to figure out when and where this are happening. In our case we don't need this two mse.play calls. Videos autplay or Players.play() does anything we need. So we think this calls are obsolete