### PR TITLE
Feature/abort

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/src/player.js
+++ b/src/player.js
@@ -80,7 +80,7 @@ export class WSPlayer {
                 Log.warn(`Client stream type ${client.streamType()} is incompatible with transport types [${transport.streamTypes().join(', ')}]. Skip`)
             }
         }
-        
+
         this.type = StreamType.RTSP;
         this.url = null;
         if (opts.url && opts.type) {
@@ -111,6 +111,14 @@ export class WSPlayer {
 
         this.player.addEventListener('pause', ()=>{
             this.client.stop();
+        }, false);
+
+        this.player.addEventListener('abort', () => {
+            // disconnect the transport when the player is closed
+            this.client.stop();
+            this.transport.disconnect().then(() => {
+                this.client.destroy();
+            });
         }, false);
     }
 


### PR DESCRIPTION
I added the `abort` event listener. This way when the player is disposed, the websocket is closed. Otherwise it would stay open forever.

I also added the [editorconfig](http://editorconfig.org/) to ensure the space code indentation. It's natively supported by a lot of IDEs.