### PR TITLE
Reuse the same session for all RTSP tracks

### DIFF
--- a/src/client/rtsp/client.js
+++ b/src/client/rtsp/client.js
@@ -32,7 +32,7 @@ export default class RTSPClient extends BaseClient {
         };
         this.sampleQueues={};
     }
-    
+
     static streamType() {
         return 'rtsp';
     }
@@ -428,6 +428,7 @@ export class RTSPClientSM extends StateMachine {
 
     sendSetup() {
         let streams=[];
+        let lastPromise = null;
 
         // TODO: select first video and first audio tracks
         for (let track_type of this.tracks) {
@@ -438,7 +439,8 @@ export class RTSPClientSM extends StateMachine {
             if (!PayloadType.string_map[track.rtpmap[track.fmt[0]].name]) continue;
 
             this.streams[track_type] = new RTSPStream(this, track);
-            let setupPromise = this.streams[track_type].start();
+            let setupPromise = this.streams[track_type].start(lastPromise);
+            lastPromise = setupPromise;
             this.parent.sampleQueues[PayloadType.string_map[track.rtpmap[track.fmt[0]].name]]=[];
             this.rtpBuffer[track.fmt[0]]=[];
             streams.push(setupPromise.then(({track, data})=>{


### PR DESCRIPTION
This solve the issue in #74.

The `SETUP` requests are now sent sequentially (and not all at once like before). The `Session` retrieved from the first `SETUP` is used for the next(s) `SETUP`.

This new behavior match the implementation of VLC and Locomote.

It may not be the most beautiful implementation but it's the easiest way without changing too much things.

Suggestion: We could add an option to choose if we want to reuse the session or not (in case there is regressions with some servers implementation).